### PR TITLE
fix: method signature for the csv parser demo

### DIFF
--- a/Demo/Shared/Data/StandardCsvParserScreen.swift
+++ b/Demo/Shared/Data/StandardCsvParserScreen.swift
@@ -47,7 +47,7 @@ private extension StandardCsvParserScreen {
             let data = FileManager.default.contents(atPath: path),
             let string = String(data: data, encoding: .utf8)
         else { return }
-        result = parser.parseCvsString(string, separator: ";")
+        result = parser.parseCsvString(string, componentSeparator: ";")
     }
 }
 


### PR DESCRIPTION
the csv string parser call was incorrectly spelt, the method signature had also been updated, this fixes these for the demo project.